### PR TITLE
Remove dependencies from gemfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,15 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](http://keepachangelog.com/).
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+
+# [Unreleased] -
+
+## Fixed
+
+- Remove useless dependencies from Gemfile (#1)
+
+
+[unreleased]: https://github.com/klaxit/fast-polylines/compare/v0.1.0...HEAD

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,3 @@ source "https://rubygems.org"
 
 # See danger-brakeman_scanner.gemspec.
 gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-BE = bundle exec
-
+BE ?= bundle exec
+VERSION = $$(ruby -r ./lib/version.rb -e 'puts DangerBrakemanScanner::VERSION')
 .PHONY: default
 default: spec
 
 .PHONY: publish
 publish: clean spec
+	git tag v$(VERSION)
+	git push origin v$(VERSION)
 	gem build
 	gem push *.gem
 
@@ -25,4 +27,4 @@ docs:
 
 .PHONY: clean
 clean:
-	rm *.gem
+	rm -f *.gem

--- a/spec/fixtures/safe_rails_app/app/models/user.rb
+++ b/spec/fixtures/safe_rails_app/app/models/user.rb
@@ -1,9 +1,7 @@
 class User < ActiveRecord::Base
-
-
-  # Yep, this is not an issue according to Brakeman.
-  # https://github.com/presidentbeef/brakeman/issues/1469
-  def not_so_dangerous_method(user_input)
-    ActiveRecord::Base.connection.execute "SELECT * FROM #{user_input}".squish
+  # https://xkcd.com/327/
+  def safe_method(user_input)
+    conn = ActiveRecord::Base.connection
+    conn.execute "SELECT * FROM #{conn.quote_table_name(user_input)}"
   end
 end


### PR DESCRIPTION
Those dependencies not grouped where conflicting with dependencies from gems using danger-brakeman_scanner.

Also updated spec according to brakeman updates.

In fact, `rspec` was already in the gemspec, and `rake` was not needed.


I also made a tiny improvement to the makefile.